### PR TITLE
chore: Fix .gitignore and add missing files from initial import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 dist
-paths
 .DS_Store
 node_modules

--- a/paths/attempts.yaml
+++ b/paths/attempts.yaml
@@ -1,0 +1,51 @@
+get:
+  operationId: getAllAttempts
+  summary: Retrieve all attempts
+  tags:
+    - Attempts
+  parameters:
+    - name: event_id
+      in: query
+      description: Filter by event ids associated with attempt
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\AttemptsResponse.yaml
+          examples:
+            Attempts:
+              $ref: ..\components\examples\Attempts.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/attempts_{id}.yaml
+++ b/paths/attempts_{id}.yaml
@@ -1,0 +1,56 @@
+get:
+  operationId: getAttempt
+  summary: Retrieve an attempt
+  description: >-
+    This endpoint retrieves a specific attempt.
+
+    
+    When retrieving a completed attempt, the response will contain the ```body``` of the destination's response.
+  tags:
+    - Attempts
+  parameters:
+    - name: id
+      in: path
+      description: Attempt ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Attempt.yaml
+          examples:
+            CompletedAttempt:
+              $ref: ..\components\examples\CompletedAttempt.yaml
+            FailedAttempt:
+              $ref: ..\components\examples\FailedAttempt.yaml              
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections.yaml
+++ b/paths/connections.yaml
@@ -1,0 +1,218 @@
+get:
+  operationId: getAllWebhookConnections
+  summary: Retrieve all webhook connections
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: query
+      description: Filter by connection ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: archived
+      in: query
+      description: Include the archived resources in response
+      required: false
+      schema:
+        type: boolean
+    - name: archived_at
+      in: query
+      description: Date the connection was archived
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: limit
+      in: query
+      description: Limit the returned event count. Max 250.
+      required: false
+      schema:
+        type: number
+        format: int32
+        maximum: 250
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnectionsResponse.yaml
+          examples:
+            WebhookConnections:
+              $ref: ..\components\examples\WebhookConnections.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+post:
+  operationId: createWebhookConnection
+  summary: Create a webhook connection
+  description: >-
+    This endpoint creates a webhook connection or updates an existing webhook
+    connection by name. A webhook connection's source and destination cannot be
+    updated.
+  tags:
+    - Webhook Connections
+  requestBody:
+    description: >-
+      ### Create a webhook connection with new resources
+
+
+      You can create a webhook connection with its underlying source,
+      destination, and ruleset with a single call by including an object for any
+      of those resources.
+
+
+      ### Create a connection with existing resources
+
+
+      You can reuse a source, a destination, or a ruleset when creating a
+      webhook connection by referencing their ID.
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\WebhookConnection.yaml
+        examples:
+          NewResources:
+            summary: Create a webhook connection with new resources
+            value:
+              name: shopify-my-api
+              source:
+                name: shopify
+              destination:
+                name: my-api
+                url: https://example.com/webhook
+          ExistingResources:
+            summary: Create a webhook connection with existing resources
+            value:
+              source_id: src_xxx
+              destination_id: des_xxx
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnections:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: upsertWebhookConnection
+  summary: Update or create (upsert) a webhook connection
+  tags:
+    - Webhook Connections
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: >-
+                ..\components\schemas\UpsertWebhookConnectionWithNewResourcesRequest.yaml
+            - $ref: >-
+                ..\components\schemas\UpsertWebhookConnectionWithExistingResourcesRequest.yaml
+        examples:
+          NewResources: # TODO: move these out to examples
+            summary: Create a webhook connection with new resources
+            value:
+              name: shopify-my-api
+              source:
+                name: shopify
+              destination:
+                name: my-api
+                url: https://example.com/webhook
+          ExistingResources:
+            summary: Create a webhook connection with existing resources
+            value:
+              source_id: src_xxx
+              destination_id: des_xxx
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnections:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections_{id}.yaml
+++ b/paths/connections_{id}.yaml
@@ -1,0 +1,126 @@
+get:
+  operationId: getWebhookConnection
+  summary: Retrieve a webhook connection
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: updateWebhookConnection
+  summary: Update a webhook connection
+  description: This endpoint updates a webhook connection.
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: >-
+                ..\components\schemas\UpdateWebhookConnectionWithNewResourcesRequest.yaml
+            - $ref: >-
+                ..\components\schemas\UpdateWebhookConnectionWithExistingResourcesRequest.yaml
+        examples:
+          NewResources:
+            summary: Update a webhook connection with new resources
+            value:
+              rules:
+                name: fast-retry-ruleset
+                rules:
+                  - type: retry
+                    strategy: linear
+                    count: 10
+                    interval: 60000
+                  - type: alert
+                    interval: 3600000
+                    strategy: last_attempt
+          ExistingResources:
+            summary: Update a webhook connection with existing resources
+            value:
+              ruleset_id: rls_YZCDPNVHORE8BZ86aDRyRMtZ
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections_{id}_archive.yaml
+++ b/paths/connections_{id}_archive.yaml
@@ -1,0 +1,55 @@
+put:
+  operationId: archiveWebhookConnection
+  summary: Archive a webhook connection
+  description: >-
+    This endpoint archives a connection. A archived connection will no longer
+    receive or deliver any webhooks.
+
+
+    The parameter ```archived_at``` is set to the current timestamp.
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\ArchivedWebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections_{id}_pause.yaml
+++ b/paths/connections_{id}_pause.yaml
@@ -1,0 +1,56 @@
+put:
+  operationId: pauseWebhookConnection
+  summary: Pause a webhook connection
+  description: >-
+    This endpoint pauses a connection. A paused connection will still receive
+    events but those events will be marked on ```HOLD``` and will not be
+    delivered until the connection is unpaused.
+
+
+    The parameter ```paused_at``` is set to the current timestamp.
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections_{id}_unarchive.yaml
+++ b/paths/connections_{id}_unarchive.yaml
@@ -1,0 +1,55 @@
+put:
+  operationId: unarchiveWebhookConnection
+  summary: Unarchive a webhook connection
+  description: >-
+    This endpoint unarchives a connection. The associated source/destination
+    will also be unarchived if they were previously archived.
+
+
+    The parameter ```archived_at``` is set to null
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/connections_{id}_unpause.yaml
+++ b/paths/connections_{id}_unpause.yaml
@@ -1,0 +1,57 @@
+put:
+  operationId: unpauseWebhookConnection
+  summary: Unpause a webhook connection
+  description: >-
+    This endpoint unpauses a connection. The on ```HOLD``` events will begin
+    delivering (throttled delivery configuration will be respected). The
+    operation is asynchronous and it could take some time for all events on
+    ```HOLD``` to be ```QUEUED``` for delivery.
+
+
+    The parameter ```paused_at``` is set to null
+  tags:
+    - Webhook Connections
+  parameters:
+    - name: id
+      in: path
+      description: Webhook connection ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\WebhookConnection.yaml
+          examples:
+            WebhookConnection:
+              $ref: ..\components\examples\WebhookConnection.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/destinations.yaml
+++ b/paths/destinations.yaml
@@ -1,0 +1,196 @@
+get:
+  operationId: getAllDestinations
+  summary: Retrieve all destinations
+  tags:
+    - Destinations
+  parameters:
+    - name: id
+      in: query
+      description: Filter by destination ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: name
+      in: query
+      description: The destination name
+      required: false
+      schema:
+        type: string
+    - name: archived
+      in: query
+      description: Include the archived resources in response
+      required: false
+      schema:
+        type: boolean
+    - name: archived_at
+      in: query
+      description: Date the destination was archived
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: url
+      in: query
+      description: HTTP endpoint of the destination
+      required: false
+      schema:
+        type: string        
+    - name: cli_path
+      in: query
+      description: Path for the CLI destination
+      required: false
+      schema:
+        type: string   
+    - name: limit
+      in: query
+      description: Limit the returned event count. Max 250.
+      required: false
+      schema:
+        type: number
+        format: int32
+        maximum: 250
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\DestinationsResponse.yaml
+          examples:
+            Destinations:
+              $ref: ..\components\examples\Destinations.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+post:
+  operationId: createDestination
+  summary: Create a destination
+  description: This endpoint creates a destination
+  tags:
+    - Destinations
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertDestinationRequest.yaml
+        example:
+          name: my-api
+          url: https://example.com/webhook
+          rate_limit: 5
+          rate_limit_period: second
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\Destination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: upsertDestination
+  summary: Update or create (upsert) a destination
+  description: This endpoint creates a destination, or updates an existing destination by name
+  tags:
+    - Destinations
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertDestinationRequest.yaml
+        example:
+          name: my-api
+          url: https://example.com/webhook
+          rate_limit: 5
+          rate_limit_period: second
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\Destination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/destinations_{id}.yaml
+++ b/paths/destinations_{id}.yaml
@@ -1,0 +1,112 @@
+get:
+  operationId: getDestination
+  summary: Retrieve a destination
+  tags:
+    - Destinations
+  parameters:
+    - name: id
+      in: path
+      description: Destination ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\Destination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: updateDestination
+  summary: Update a destination
+  description: >-
+    This endpoint updates a destination. 
+
+    One of ```url``` or ```cli_path``` is required.
+  tags:
+    - Destinations
+  parameters:
+    - name: id
+      in: path
+      description: Destination ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertDestinationRequest.yaml
+        example:
+          name: my-api
+          url: https://example.com/webhook
+          rate_limit: 5
+          rate_limit_period: second
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\UpsertedDestination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/destinations_{id}_archive.yaml
+++ b/paths/destinations_{id}_archive.yaml
@@ -1,0 +1,54 @@
+put:
+  operationId: archiveDestination
+  summary: Archive a destination 
+  description: >-
+    This endpoint archives a destination and any associated webhook connections.
+
+    
+    The parameter ```archived_at``` is set to the current timestamp.
+  tags:
+    - Destinations
+  parameters:
+    - name: id
+      in: path
+      description: Destination ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\ArchivedDestination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/destinations_{id}_unarchive.yaml
+++ b/paths/destinations_{id}_unarchive.yaml
@@ -1,0 +1,54 @@
+put:
+  operationId: unarchiveDestination
+  summary: Unarchive a destination
+  description: >-
+    Unarchive a destination.
+
+    
+    The parameter ```archived_at``` is set to null
+  tags:
+    - Destinations
+  parameters:
+    - name: id
+      in: path
+      description: Destination ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Destination.yaml
+          examples:
+            Destination:
+              $ref: ..\components\examples\Destination.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/events.yaml
+++ b/paths/events.yaml
@@ -1,0 +1,210 @@
+get:
+  operationId: getAllEvents
+  summary: Retrieve all events
+  description: >-
+    This endpoint lists all events, or a subset of events.
+
+
+    ### Filtering events
+    
+    To filter the list of events, use only supported operators.
+
+
+    For example, append ```?created_at[gte]=2021-10-12&created_at[lte]=2021-10-13``` to retrieve events for that specific 24-hour period.
+
+
+    ### Including event data
+    
+    To retrieve events with their ```data``` populated, use the ```?include=data``` query parameter. Be aware that this can lead to very large responses.
+
+
+    Payload data exceeding 2.5 MB won't be returned, and ```data.body``` will be set to ```null```. The request path, query and headers are still included.
+
+
+    > To distinguish between these large payloads and payloads set to the JSON literal ```null```, leverage ```headers['content-length']```.
+
+
+    ### Including CLI events
+
+    CLI events are excluded from the results by default. To query CLI events, use ```/events?cli_id[any]=true```.
+  tags:
+    - Events
+  parameters:
+    - name: id
+      in: query
+      description: Filter by event ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: webhook_id
+      in: query
+      description: Filter by webhook connection ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: source_id
+      in: query
+      description: Filter by source ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string     
+    - name: destination_id
+      in: query
+      description: Filter by destination ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string 
+    - name: cli_id
+      in: query
+      description: Filter by CLI IDs. ```?[any]=true``` operator for any CLI. Defaults to null
+      required: false
+      schema:
+        type: array
+        items:
+          type: string              
+    - name: status
+      in: query
+      description: Lifecyle status of the event
+      required: false
+      schema:
+        type: string
+        enum:
+          - QUEUED
+          - HOLD
+          - SUCCESSFUL
+          - FAILED
+    - name: response_status
+      in: query
+      description: Filter by HTTP response status code
+      required: false
+      schema:
+        type: number
+    - name: attempts
+      in: query
+      description: Filter by number of attempts
+      required: false
+      schema:
+        type: number
+    - name: created_at
+      in: query
+      description: Filter by created_at date using a date operator
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: successful_at
+      in: query
+      description: Filter by successful_at date using a date operator
+      required: false
+      schema:
+        type: string
+        format: date       
+    - name: last_attempt_at
+      in: query
+      description: Filter by last_attempt_at date using a date operator
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: next_attempt_at
+      in: query
+      description: Filter by next_attempt_at date using a date operator
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: body
+      in: query
+      description: URL Encoded string of the JSON to match to the data body
+      required: false
+      schema:
+        type: string
+    - name: headers
+      in: query
+      description: URL Encoded string of the JSON to match to the data headers
+      required: false
+      schema:
+        type: string        
+    - name: parsed_query
+      in: query
+      description: URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)
+      required: false
+      schema:
+        type: string  
+    - name: path
+      in: query
+      description: URL Encoded string of the string to match partially to the path
+      required: false
+      schema:
+        type: string                  
+    - name: include
+      in: query
+      description: Include the data object in the event model
+      required: false
+      schema:
+        type: string  
+        enum:
+          - data    
+    - name: limit
+      in: query
+      description: Limit the returned event count. Max 250.
+      required: false
+      schema:
+        type: number
+        format: int32
+        maximum: 250
+    - name: order_by
+      in: query
+      description: Specify order column
+      required: false
+      schema:
+        type: string 
+        enum:
+          - created_at
+          - last_attempt_at
+        default: created_at        
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\EventsResponse.yaml
+          examples:
+            Events:
+              $ref: ..\components\examples\Events.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/events_{id}.yaml
+++ b/paths/events_{id}.yaml
@@ -1,0 +1,54 @@
+get:
+  operationId: getEvent
+  summary: Retrieve an event
+  description: >-
+    This endpoint retrieves a specific event.
+
+
+    The response contains the ```data``` object with the properties ```body``` and ```headers```, representing the original data for that webhook request.
+  tags:
+    - Events
+  parameters:
+    - name: id
+      in: path
+      description: Event ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Event.yaml
+          examples:
+            Event:
+              $ref: ..\components\examples\Event.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/events_{id}_mute.yaml
+++ b/paths/events_{id}_mute.yaml
@@ -1,0 +1,54 @@
+put:
+  operationId: muteEvent
+  summary: Mute an event 
+  description: >- 
+    This endpoint cancels the next automatic retry.
+
+
+    The parameter ```next_attempt_at``` is set to null. This action is not reversible.
+  tags:
+    - Events
+  parameters:
+    - name: id
+      in: path
+      description: Event ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Event.yaml
+          examples:
+            MutedEvent:
+              $ref: ..\components\examples\MutedEvent.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/events_{id}_retry.yaml
+++ b/paths/events_{id}_retry.yaml
@@ -1,0 +1,50 @@
+put:
+  operationId: retryEvent
+  summary: Retry an event 
+  description: This endpoint manually queues an event for retry.
+  tags:
+    - Events
+  parameters:
+    - name: id
+      in: path
+      description: Event ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\RetryEventResponse.yaml
+          examples:
+            RetriedEvent:
+              $ref: ..\components\examples\RetriedEvent.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/rulesets.yaml
+++ b/paths/rulesets.yaml
@@ -1,0 +1,191 @@
+get:
+  operationId: getAllRulesets
+  summary: Retrieve all rulesets
+  tags:
+    - Rulesets
+  parameters:
+    - name: id
+      in: query
+      description: Filter by ruleset ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: name
+      in: query
+      description: The ruleset name
+      required: false
+      schema:
+        type: string
+    - name: archived
+      in: query
+      description: Include the archived resources in response
+      required: false
+      schema:
+        type: boolean
+    - name: archived_at
+      in: query
+      description: Date the ruleset  was archived
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: limit
+      in: query
+      description: Limit the returned event count. Max 250.
+      required: false
+      schema:
+        type: number
+        format: int32
+        maximum: 250
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\RulesetsResponse.yaml
+          examples:
+            Rulesets:
+              $ref: ..\components\examples\Rulesets.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+post:
+  operationId: createRuleset
+  summary: Create a ruleset
+  description: This endpoint creates a ruleset
+  tags:
+    - Rulesets
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertRulesetRequest.yaml
+        example:
+          name: fast-retry-ruleset
+          rules:
+          - type: retry
+            strategy: linear
+            count: 10
+            interval: 60000
+          - type: alert
+            interval: 3600000
+            strategy: last_attempt
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\Ruleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: upsertRuleset
+  summary: Update or create (upsert) a ruleset
+  description: This endpoint creates a ruleset, or updates an existing ruleset by name
+  tags:
+    - Rulesets
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertRulesetRequest.yaml
+        example:
+          name: fast-retry-ruleset
+          rules:
+          - type: retry
+            strategy: linear
+            count: 10
+            interval: 60000
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\UpsertedRuleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/rulesets_{id}.yaml
+++ b/paths/rulesets_{id}.yaml
@@ -1,0 +1,111 @@
+get:
+  operationId: getRuleset
+  summary: Retrieve a ruleset
+  tags:
+    - Rulesets
+  parameters:
+    - name: id
+      in: path
+      description: Ruleset ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\Ruleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: updateRuleset
+  summary: Update a ruleset
+  description: This endpoint updates a ruleset.
+  tags:
+    - Rulesets
+  parameters:
+    - name: id
+      in: path
+      description: Ruleset ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertRulesetRequest.yaml
+        example:
+          name: fast-retry-ruleset
+          rules:
+          - type: retry
+            strategy: linear
+            count: 10
+            interval: 60000
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\UpsertedRuleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/rulesets_{id}_archive.yaml
+++ b/paths/rulesets_{id}_archive.yaml
@@ -1,0 +1,54 @@
+put:
+  operationId: archiveRuleset
+  summary: Archive a ruleset 
+  description: >-
+    This endpoint archives a ruleset.
+
+    
+    The parameter ```archived_at``` is set to the current timestamp.
+  tags:
+    - Rulesets
+  parameters:
+    - name: id
+      in: path
+      description: Ruleset ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\ArchivedRuleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/rulesets_{id}_unarchive.yaml
+++ b/paths/rulesets_{id}_unarchive.yaml
@@ -1,0 +1,54 @@
+put:
+  operationId: unarchiveRuleset
+  summary: Unarchive a ruleset
+  description: >-
+    Unarchive a ruleset.
+
+    
+    The parameter ```archived_at``` is set to null
+  tags:
+    - Rulesets
+  parameters:
+    - name: id
+      in: path
+      description: Ruleset ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Ruleset.yaml
+          examples:
+            Ruleset:
+              $ref: ..\components\examples\Ruleset.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/sources.yaml
+++ b/paths/sources.yaml
@@ -1,0 +1,178 @@
+get:
+  operationId: getAllSources
+  summary: Retrieve all sources
+  tags:
+    - Sources
+  parameters:
+    - name: id
+      in: query
+      description: Filter by source ids
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: name
+      in: query
+      description: The source name
+      required: false
+      schema:
+        type: string
+    - name: archived
+      in: query
+      description: Include the archived resources in response
+      required: false
+      schema:
+        type: boolean
+    - name: archived_at
+      in: query
+      description: Date the source was archived
+      required: false
+      schema:
+        type: string
+        format: date
+    - name: limit
+      in: query
+      description: Limit the returned event count. Max 250.
+      required: false
+      schema:
+        type: number
+        format: int32
+        maximum: 250
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\SourcesResponse.yaml
+          examples:
+            Sources:
+              $ref: ..\components\examples\Sources.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+post:
+  operationId: createSource
+  summary: Create a source
+  description: This endpoint creates a source
+  tags:
+    - Sources
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertSourceRequest.yaml
+        example:
+          name: shopify
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\Source.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: upsertSource
+  summary: Update or create (upsert) a source
+  description: This endpoint creates a source, or updates an existing source by name
+  tags:
+    - Sources
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertSourceRequest.yaml
+        example:
+          name: shopify
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\Source.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/sources_{id}.yaml
+++ b/paths/sources_{id}.yaml
@@ -1,0 +1,106 @@
+get:
+  operationId: getSource
+  summary: Retrieve a source
+  tags:
+    - Sources
+  parameters:
+    - name: id
+      in: path
+      description: Source ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\Source.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml
+put:
+  operationId: updateSource
+  summary: Update a source
+  description: This endpoint updates a source.
+  tags:
+    - Sources
+  parameters:
+    - name: id
+      in: path
+      description: Source ID
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ..\components\schemas\UpsertSourceRequest.yaml
+        example:
+          name: shopify
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\Source.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/sources_{id}_archive.yaml
+++ b/paths/sources_{id}_archive.yaml
@@ -1,0 +1,53 @@
+put:
+  operationId: archiveSource
+  summary: Archive a source 
+  description: >-
+    This endpoint archives a source and any associated webhook connections.
+
+    The parameter ```archived_at``` is set to the current timestamp.
+  tags:
+    - Sources
+  parameters:
+    - name: id
+      in: path
+      description: Source ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\ArchivedSource.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml

--- a/paths/sources_{id}_unarchive.yaml
+++ b/paths/sources_{id}_unarchive.yaml
@@ -1,0 +1,53 @@
+put:
+  operationId: unarchiveSource
+  summary: Unarchive a source
+  description: >-
+    Unarchive a source.
+
+    The parameter ```archived_at``` is set to null
+  tags:
+    - Sources
+  parameters:
+    - name: id
+      in: path
+      description: Source ID
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ..\components\schemas\Source.yaml
+          examples:
+            Source:
+              $ref: ..\components\examples\Source.yaml
+      headers:
+        Retry-After:
+          $ref: ..\components\headers\Retry-After.yaml
+        X-RateLimit-Limit:
+          $ref: ..\components\headers\X-RateLimit-Limit.yaml
+        X-RateLimit-Limit-Remaining:
+          $ref: ..\components\headers\X-RateLimit-Remaining.yaml
+        X-RateLimit-Limit-Reset:
+          $ref: ..\components\headers\X-RateLimit-Reset.yaml
+    '400':
+      $ref: ..\components\responses\400.yaml
+    '401':
+      $ref: ..\components\responses\401.yaml
+    '403':
+      $ref: ..\components\responses\403.yaml
+    '404':
+      $ref: ..\components\responses\404.yaml
+    '413':
+      $ref: ..\components\responses\413.yaml
+    '422':
+      $ref: ..\components\responses\422.yaml
+    '429':
+      $ref: ..\components\responses\429.yaml
+    '500':
+      $ref: ..\components\responses\500.yaml
+    '503':
+      $ref: ..\components\responses\503.yaml


### PR DESCRIPTION
`paths` folder was added to `.gitignore` (probably by a mistake) so the initial import wasn't complete. This PR will remove the `paths` from `.gitignore` and add missing files from the initial import.